### PR TITLE
Prevent the UI to not allow the user to add more than one config block

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1,6 +1,7 @@
 {
   "pluginAlias": "Jablotron",
   "pluginType": "platform",
+  "singular": true,
   "headerDisplay": "This plugin works with Jablotron Alarms.\n\n1. Open the Home <img src='https://user-images.githubusercontent.com/3979615/78010622-4ea1d380-738e-11ea-8a17-e6a465eeec35.png' height='16.42px'> app on your device.\n2. Tap the Home tab, then tap <img src='https://user-images.githubusercontent.com/3979615/78010869-9aed1380-738e-11ea-9644-9f46b3633026.png' height='16.42px'>.\n3. Tap *Add Accessory*, and select *I Don't Have a Code or select More Options*.\n4. Select Accessory and Enter the Homebridge PIN, or scan the QR code in Homebridge UI.",
   "footerDisplay": "Control your Jablotron alarm system from your iOS device using HomeKit and Homebridge, which is available [here](https://github.com/fdegier/homebridge-jablotron-alarm.git).",
   "schema": {


### PR DESCRIPTION
Prevent the UI to not allow the user to add more than one config block. This is usually used for platform plugins where only a single config block should be present.