### PR TITLE
Bump to 2.6.1-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-jablotron",
-  "version": "2.6.0",
+  "version": "2.6.1-beta.1",
   "description": "Control your Jablotron alarm system from your iOS device using HomeKit and Homebridge.",
   "license": "MIT",
   "homepage": "https://github.com/fdegier/homebridge-jablotron-alarm#readme",


### PR DESCRIPTION
Trial PR to bump the version to a beta to verify the behavior of Homebridge packaging.