### PR TITLE
Config helper fixed to indicate support of partial arming for a section

### DIFF
--- a/config-helper.js
+++ b/config-helper.js
@@ -65,6 +65,10 @@ JablotronConfigHelper.prototype = {
         } else {
             result.segment_id = segment['cloud-component-id'];
         }
+
+        if (true === segment['partial-arm-enabled']) {
+            result.partiallyArmedMode = 'Home'
+        }
         return result;
     },
 


### PR DESCRIPTION
Forgot to add support for partial arming to config helper tool. Here it comes 